### PR TITLE
Stop using Oracle JDK 8 in CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 scala:
   - 2.11.12
 jdk:
-  - oraclejdk8
   - openjdk8
 test:
   - sbt sbt:scalafmt::test


### PR DESCRIPTION
ATM, the oraclejdk build image is failing because it allows only version 9-14 (I believe 8 is not allowed for commercial use). Let's just remove it, we've switched to openjdk in all other scala repos as well.